### PR TITLE
fix: make setup work with direct-download Slack

### DIFF
--- a/src/slack_mcp/setup.py
+++ b/src/slack_mcp/setup.py
@@ -1,11 +1,57 @@
 from __future__ import annotations
 
-import re
 import subprocess
 import sys
 from datetime import datetime, timezone
 
-TOKEN_RE = re.compile(r"xoxc-[a-zA-Z0-9-]+")
+# Account names used by pycookiecheat to look up the Slack decryption key.
+# App Store Slack uses "Slack App Store Key"; direct-download uses "Slack Key".
+_SLACK_KEYCHAIN_ACCOUNTS = ["Slack App Store Key", "Slack Key"]
+
+
+def _patch_pycookiecheat_for_direct_download() -> None:
+    """Patch pycookiecheat to try both Slack keychain account names.
+
+    pycookiecheat hardcodes "Slack App Store Key", which fails for
+    direct-download Slack installs that use "Slack Key" instead.
+    """
+    try:
+        import keyring
+        import pycookiecheat.chrome as _pc
+        from pathlib import Path
+        from pycookiecheat.chrome import BrowserType
+    except ImportError:
+        return  # pycookiecheat not installed; slacktokens will surface its own error
+
+    _orig = _pc.get_macos_config
+
+    def _patched(browser: BrowserType) -> dict:
+        try:
+            return _orig(browser)
+        except ValueError:
+            if browser is not BrowserType.SLACK:
+                raise
+            # Try alternative keychain account names for direct-download Slack
+            for account in _SLACK_KEYCHAIN_ACCOUNTS:
+                key_material = keyring.get_password("Slack Safe Storage", account)
+                if key_material is not None:
+                    cookie_file = (
+                        Path.home() / "Library/Application Support/Slack/Cookies"
+                    )
+                    if not cookie_file.exists():
+                        cookie_file = (
+                            Path.home()
+                            / "Library/Containers/com.tinyspeck.slackmacgap"
+                            / "Data/Library/Application Support/Slack/Cookies"
+                        )
+                    return {
+                        "key_material": key_material,
+                        "iterations": 1003,
+                        "cookie_file": cookie_file,
+                    }
+            raise  # no account name worked; surface the original error
+
+    _pc.get_macos_config = _patched
 
 
 def main() -> None:
@@ -31,13 +77,16 @@ def main() -> None:
         sys.exit(1)
 
     # Step 3: Extract tokens
-    import httpx
-
     from slack_mcp.auth import Credentials, WorkspaceCredential, save_credentials
+
+    # pycookiecheat hardcodes "Slack App Store Key" as the keychain account name,
+    # but direct-download Slack uses "Slack Key". Patch it to try both.
+    _patch_pycookiecheat_for_direct_download()
 
     print("Extracting Slack tokens...")
     token_data = slacktokens.get_tokens_and_cookie()
-    cookie = token_data.get("cookie", "")
+    # cookie is returned as {'name': 'd', 'value': 'xoxd-...'}
+    d_cookie: str = token_data.get("cookie", {}).get("value", "")
     tokens: dict = token_data.get("tokens", {})
 
     workspaces: dict[str, WorkspaceCredential] = {}
@@ -48,25 +97,13 @@ def main() -> None:
             .removesuffix("/")
             .replace(".slack.com", "")
         )
-        d_cookie = token_info.get("d_cookie") or cookie
-
-        try:
-            resp = httpx.get(
-                workspace_url,
-                headers={"Cookie": f"d={d_cookie}"},
-                follow_redirects=True,
+        # slacktokens extracts the xoxc- token directly from LevelDB localStorage
+        xoxc_token: str = token_info.get("token", "")
+        if not xoxc_token:
+            print(
+                f"Warning: no token found for '{workspace_name}', skipping.",
+                file=sys.stderr,
             )
-            match = TOKEN_RE.search(resp.text)
-            if not match:
-                print(
-                    f"Warning: could not extract xoxc- token for"
-                    f" '{workspace_name}', skipping.",
-                    file=sys.stderr,
-                )
-                continue
-            xoxc_token = match.group(0)
-        except Exception as e:
-            print(f"Warning: failed to fetch '{workspace_url}': {e}", file=sys.stderr)
             continue
 
         workspaces[workspace_name] = WorkspaceCredential(

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -6,9 +6,7 @@ import pytest
 
 def test_main_exits_if_slacktokens_missing(monkeypatch):
     """If slacktokens is not importable, exit 1 with instructions."""
-    # Remove slacktokens from sys.modules if present, and make it unimportable
     monkeypatch.setitem(sys.modules, "slacktokens", None)
-    # Re-import to get a fresh module state
     if "slack_mcp.setup" in sys.modules:
         del sys.modules["slack_mcp.setup"]
     from slack_mcp.setup import main
@@ -20,13 +18,79 @@ def test_main_exits_if_slacktokens_missing(monkeypatch):
 
 def test_main_exits_if_slack_running(monkeypatch):
     """If Slack app is running (pgrep returns 0), exit 1."""
-    # Make slacktokens importable as a mock
     mock_slacktokens = MagicMock()
     monkeypatch.setitem(sys.modules, "slacktokens", mock_slacktokens)
     if "slack_mcp.setup" in sys.modules:
         del sys.modules["slack_mcp.setup"]
 
     with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+        from slack_mcp import setup as setup_mod
+
+        with pytest.raises(SystemExit) as exc:
+            setup_mod.main()
+    assert exc.value.code == 1
+
+
+def test_main_extracts_tokens_from_leveldb(monkeypatch, tmp_path):
+    """Tokens and cookie are read directly from slacktokens output (no HTTP needed)."""
+    mock_slacktokens = MagicMock()
+    mock_slacktokens.get_tokens_and_cookie.return_value = {
+        "tokens": {
+            "https://test-workspace.slack.com/": {
+                "token": "xoxc-abc123",
+                "name": "Test Workspace",
+            }
+        },
+        "cookie": {"name": "d", "value": "xoxd-xyz789"},
+    }
+    monkeypatch.setitem(sys.modules, "slacktokens", mock_slacktokens)
+    if "slack_mcp.setup" in sys.modules:
+        del sys.modules["slack_mcp.setup"]
+
+    creds_dir = tmp_path / ".config" / "slack-mcp"
+    creds_dir.mkdir(parents=True)
+
+    with (
+        patch("subprocess.run", return_value=MagicMock(returncode=1)),
+        patch("slack_mcp.setup._patch_pycookiecheat_for_direct_download"),
+        patch(
+            "slack_mcp.auth.CREDENTIALS_PATH",
+            tmp_path / ".config" / "slack-mcp" / "credentials.json",
+        ),
+    ):
+        from slack_mcp import setup as setup_mod
+
+        setup_mod.main()
+
+    from slack_mcp.auth import load_credentials
+
+    with patch(
+        "slack_mcp.auth.CREDENTIALS_PATH",
+        tmp_path / ".config" / "slack-mcp" / "credentials.json",
+    ):
+        creds = load_credentials()
+
+    assert "test-workspace" in creds.workspaces
+    ws = creds.workspaces["test-workspace"]
+    assert ws.token == "xoxc-abc123"
+    assert ws.d_cookie == "xoxd-xyz789"
+
+
+def test_main_exits_if_no_workspaces_extracted(monkeypatch):
+    """If all workspaces are skipped (no tokens), exit 1."""
+    mock_slacktokens = MagicMock()
+    mock_slacktokens.get_tokens_and_cookie.return_value = {
+        "tokens": {},
+        "cookie": {"name": "d", "value": "xoxd-xyz"},
+    }
+    monkeypatch.setitem(sys.modules, "slacktokens", mock_slacktokens)
+    if "slack_mcp.setup" in sys.modules:
+        del sys.modules["slack_mcp.setup"]
+
+    with (
+        patch("subprocess.run", return_value=MagicMock(returncode=1)),
+        patch("slack_mcp.setup._patch_pycookiecheat_for_direct_download"),
+    ):
         from slack_mcp import setup as setup_mod
 
         with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary

- `slacktokens` returns `cookie` as `{'name': 'd', 'value': '...'}` — we were grabbing the whole dict instead of `.value`
- `slacktokens` already extracts the `xoxc-` token from LevelDB; the HTTP GET to workspace URLs was unnecessary and is removed
- `pycookiecheat` hardcodes `"Slack App Store Key"` as the keychain account name; direct-download Slack uses `"Slack Key"` — patched to try both

## Test plan
- [ ] `pytest tests/unit/` passes (40 tests)
- [ ] `slack-mcp-setup` runs end-to-end on a machine with direct-download Slack