### PR TITLE
fix: prevent test from clobbering real credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,139 @@
 # slack-mcp
 
-A read-only Slack MCP server for Claude Code, using cookie-based authentication.
-No OAuth app required.
+Ask Claude about your Slack — without setting up an OAuth app.
+
+`slack-mcp` is a read-only [MCP](https://modelcontextprotocol.io/) server that gives
+Claude Code access to your Slack workspaces using the same session tokens the Slack
+desktop app uses internally. One-time setup, no app approval process, no OAuth dance.
+
+## What you can do
+
+Once installed, ask Claude things like:
+
+- *"What channels am I in on the acme workspace?"*
+- *"Search for messages about the Q3 launch in #general"*
+- *"Summarize the last 50 messages in #engineering"*
+- *"Who posted in that thread from yesterday?"*
+- *"List everyone in the design workspace"*
+
+All reads. No posting, no mutations — read-only by design.
 
 ## How it works
 
-Uses the same `xoxc-`/`xoxd-` tokens the Slack desktop app uses internally.
-Tokens are extracted once from the local Slack installation and cached in
-`~/.config/slack-mcp/credentials.json`.
+Slack's desktop app stores session tokens (`xoxc-`) in a local LevelDB database and
+a paired cookie (`xoxd-`) in the system keychain. `slack-mcp-setup` extracts both
+once and caches them in `~/.config/slack-mcp/credentials.json`. The MCP server reads
+that file at startup and uses the tokens directly for every API call.
+
+No Slack app registration required. No OAuth. Tokens are scoped to your own account.
+
+## Requirements
+
+- **macOS** (token extraction uses the macOS keychain; Linux not supported in v1)
+- **Python 3.11** — required for both setup and the server (`slacktokens` requires `<3.12`)
+- **Claude Code** — the MCP server registers as a local stdio server
+- **Slack desktop app** installed (tokens are read from its local storage)
 
 ## Installation
 
 ```bash
-# 1. Clone and install
+# 1. Clone the repo
 git clone https://github.com/smartwatermelon/slack-mcp
 cd slack-mcp
-pip install -e ".[setup]"   # includes slacktokens
 
-# 2. Extract tokens (Slack must be QUIT first)
+# 2. Create a Python 3.11 environment (required — slacktokens does not support 3.12+)
+python3.11 -m venv .venv
+source .venv/bin/activate
+
+# 3. Install with setup extras (pulls in slacktokens + leveldb)
+pip install -e ".[setup]"
+
+# 4. Quit Slack, then extract tokens
+#    (LevelDB does not support concurrent access — Slack must be fully quit)
 osascript -e 'quit app "Slack"'
 slack-mcp-setup
 
-# 3. Register with Claude Code
-claude mcp add slack-mcp -- slack-mcp-server
+# 5. Register with Claude Code
+claude mcp add slack-mcp -- /path/to/slack-mcp/.venv/bin/slack-mcp-server
+
+# 6. Restart Slack
+open -a Slack
 ```
+
+After step 5, restart your Claude Code session. The server connects automatically at startup.
+
+### Getting Python 3.11
+
+If you don't have Python 3.11:
+
+```bash
+# Using Homebrew
+brew install python@3.11
+
+# Using uv
+uv python install 3.11
+uv venv --python 3.11 .venv
+```
+
+### Multiple workspaces
+
+`slack-mcp-setup` extracts tokens for **all** workspaces your Slack app is signed into.
+Tools default to the first workspace; pass `workspace="name"` to target a specific one:
+
+*"List channels in the acme workspace"* — Claude will pass `workspace="acme"` automatically.
 
 ## Tools
 
-| Tool | Description |
-|---|---|
-| `list_workspaces` | List all configured workspaces |
-| `list_channels` | List channels (public and/or private) |
-| `get_channel_history` | Get recent messages from a channel |
-| `get_thread` | Get all replies in a thread |
-| `search_messages` | Full-text search across a workspace |
-| `get_channel_info` | Get channel metadata |
-| `get_user_info` | Get user profile by ID |
-| `list_users` | List workspace members |
-
-All tools accept an optional `workspace` parameter. If omitted, the first
-configured workspace is used.
+| Tool | Parameters | Description |
+|---|---|---|
+| `list_workspaces` | — | List all configured workspaces |
+| `list_channels` | `workspace`, `types`, `limit` | List channels (public and/or private) |
+| `get_channel_history` | `channel_id`, `workspace`, `limit`, `oldest`, `latest` | Get messages from a channel |
+| `get_thread` | `channel_id`, `thread_ts`, `workspace`, `limit` | Get all replies in a thread |
+| `search_messages` | `query`, `workspace`, `count`, `sort` | Full-text search |
+| `get_channel_info` | `channel_id`, `workspace` | Channel metadata |
+| `get_user_info` | `user_id`, `workspace` | User profile by ID |
+| `list_users` | `workspace`, `limit` | List workspace members |
 
 ## Token refresh
 
-Tokens expire after approximately one year. To refresh:
+Tokens are valid for approximately one year. When they expire, re-run setup:
 
 ```bash
 osascript -e 'quit app "Slack"'
 slack-mcp-setup
+open -a Slack
 ```
+
+The server will pick up the new tokens on next restart.
 
 ## Security
 
-`~/.config/slack-mcp/credentials.json` is written with mode `0600`.
-The `xoxc-`/`xoxd-` tokens grant full Slack access equivalent to your login.
-Never share or commit this file.
+- `~/.config/slack-mcp/credentials.json` is written with mode `0600` (owner read/write only)
+- The `xoxc-`/`xoxd-` tokens grant full Slack access equivalent to your login
+- **Never share or commit `credentials.json`** — treat it like a password
+- The server is read-only: no Slack API write operations are exposed
+
+## Troubleshooting
+
+**"Slack is running" error during setup**
+Slack must be fully quit — `Cmd+Q`, not just closing the window. Use
+`osascript -e 'quit app "Slack"'` to ensure it exits.
+
+**"Could not find a password for Slack Safe Storage" error**
+Your Slack install (App Store vs. direct download) uses a different keychain account
+name than `slacktokens` expects. This is handled automatically since v1.1. If you see
+this on an older install, update to the latest version.
+
+**Server shows only one workspace / wrong workspace**
+Re-run `slack-mcp-setup` to refresh credentials, then restart your Claude Code session.
+
+**Tokens expired / "invalid_auth" errors**
+Re-run `slack-mcp-setup` (see Token refresh above).
 
 ## Known limitations
 
-- **macOS only** for token extraction (`slacktokens` reads the macOS keychain)
+- **macOS only** — `slacktokens` reads the macOS keychain; Linux support is not planned for v1
+- **Python 3.11 required** — `slacktokens` does not support Python 3.12+
 - **No write operations** — read-only by design in v1
 - **Slack must be quit during setup** — LevelDB does not support concurrent access

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -31,7 +31,7 @@ def test_main_exits_if_slack_running(monkeypatch):
     assert exc.value.code == 1
 
 
-def test_main_extracts_tokens_from_leveldb(monkeypatch, tmp_path):
+def test_main_extracts_tokens_from_leveldb(monkeypatch):
     """Tokens and cookie are read directly from slacktokens output (no HTTP needed)."""
     mock_slacktokens = MagicMock()
     mock_slacktokens.get_tokens_and_cookie.return_value = {
@@ -47,31 +47,21 @@ def test_main_extracts_tokens_from_leveldb(monkeypatch, tmp_path):
     if "slack_mcp.setup" in sys.modules:
         del sys.modules["slack_mcp.setup"]
 
-    creds_dir = tmp_path / ".config" / "slack-mcp"
-    creds_dir.mkdir(parents=True)
-
+    # Patch save_credentials on auth — CREDENTIALS_PATH patching does NOT work because
+    # save_credentials captures its default path value at definition time.
     with (
         patch("subprocess.run", return_value=MagicMock(returncode=1)),
         patch("slack_mcp.setup._patch_pycookiecheat_for_direct_download"),
-        patch(
-            "slack_mcp.auth.CREDENTIALS_PATH",
-            tmp_path / ".config" / "slack-mcp" / "credentials.json",
-        ),
+        patch("slack_mcp.auth.save_credentials") as mock_save,
     ):
         from slack_mcp import setup as setup_mod
 
         setup_mod.main()
 
-    from slack_mcp.auth import load_credentials
-
-    with patch(
-        "slack_mcp.auth.CREDENTIALS_PATH",
-        tmp_path / ".config" / "slack-mcp" / "credentials.json",
-    ):
-        creds = load_credentials()
-
-    assert "test-workspace" in creds.workspaces
-    ws = creds.workspaces["test-workspace"]
+    mock_save.assert_called_once()
+    saved_creds = mock_save.call_args[0][0]
+    assert "test-workspace" in saved_creds.workspaces
+    ws = saved_creds.workspaces["test-workspace"]
     assert ws.token == "xoxc-abc123"
     assert ws.d_cookie == "xoxd-xyz789"
 


### PR DESCRIPTION
## Summary

- `save_credentials(path=CREDENTIALS_PATH)` captures the default at **definition time** (module import), so `patch("slack_mcp.auth.CREDENTIALS_PATH", ...)` has no effect on calls that use the default
- The test was silently writing to the real `~/.config/slack-mcp/credentials.json`, replacing 7 real workspaces with a single `test-workspace` entry
- Fix: patch `slack_mcp.auth.save_credentials` directly — since the import is lazy (inside `main()`), the mock is picked up correctly at call time

## Test plan
- [ ] `pytest tests/unit/` passes (40 tests)
- [ ] Running tests does not modify `~/.config/slack-mcp/credentials.json`