### PR TITLE
docs: fix README install steps for Python 3.11 / Homebrew / venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python3.11 -m venv .venv
 
 # 3. Install with setup extras (pulls in slacktokens + leveldb)
 #    If pip is blocked by your system (e.g. Homebrew-managed Python), use uv pip instead:
-#      uv pip install --python .venv -e ".[setup]"
+#      uv pip install --python .venv/bin/python -e ".[setup]"
 .venv/bin/pip install -e ".[setup]"
 
 # 4. Quit Slack, then extract tokens
@@ -77,7 +77,7 @@ brew install python@3.11
 # Using uv
 uv python install 3.11
 uv venv --python 3.11 .venv
-uv pip install --python .venv -e ".[setup]"
+uv pip install --python .venv/bin/python -e ".[setup]"
 ```
 
 If you installed Python 3.11 via Homebrew, use the `uv pip` form in step 3 above —

--- a/README.md
+++ b/README.md
@@ -43,17 +43,18 @@ cd slack-mcp
 
 # 2. Create a Python 3.11 environment (required — slacktokens does not support 3.12+)
 python3.11 -m venv .venv
-source .venv/bin/activate
 
 # 3. Install with setup extras (pulls in slacktokens + leveldb)
-pip install -e ".[setup]"
+#    If pip is blocked by your system (e.g. Homebrew-managed Python), use uv pip instead:
+#      uv pip install --python .venv -e ".[setup]"
+.venv/bin/pip install -e ".[setup]"
 
 # 4. Quit Slack, then extract tokens
 #    (LevelDB does not support concurrent access — Slack must be fully quit)
 osascript -e 'quit app "Slack"'
-slack-mcp-setup
+.venv/bin/slack-mcp-setup
 
-# 5. Register with Claude Code
+# 5. Register with Claude Code (use the absolute path to your clone)
 claude mcp add slack-mcp -- /path/to/slack-mcp/.venv/bin/slack-mcp-server
 
 # 6. Restart Slack
@@ -61,6 +62,9 @@ open -a Slack
 ```
 
 After step 5, restart your Claude Code session. The server connects automatically at startup.
+
+The venv does not need to stay active after setup. Claude Code launches the server binary
+directly via the path registered in step 5.
 
 ### Getting Python 3.11
 
@@ -73,7 +77,11 @@ brew install python@3.11
 # Using uv
 uv python install 3.11
 uv venv --python 3.11 .venv
+uv pip install --python .venv -e ".[setup]"
 ```
+
+If you installed Python 3.11 via Homebrew, use the `uv pip` form in step 3 above —
+Homebrew's Python may block `pip install` with an "externally managed environment" error.
 
 ### Multiple workspaces
 
@@ -101,7 +109,7 @@ Tokens are valid for approximately one year. When they expire, re-run setup:
 
 ```bash
 osascript -e 'quit app "Slack"'
-slack-mcp-setup
+/path/to/slack-mcp/.venv/bin/slack-mcp-setup
 open -a Slack
 ```
 


### PR DESCRIPTION
## Summary

- Remove shell `source .venv/bin/activate` from install steps — use `.venv/bin/pip` and `.venv/bin/slack-mcp-setup` directly (no activation needed at any point)
- Add `uv pip install --python .venv` as the explicit alternative for Homebrew users who hit the PEP 668 "externally managed environment" error
- Complete the uv path in "Getting Python 3.11" — previously the section created the venv but never showed the install step
- Add note clarifying the venv does not need to stay active after setup; Claude Code launches the server via the registered binary path
- Update Token refresh section to use the full venv binary path for consistency

## Test plan

- [ ] Follow main installation path on a fresh machine with Python 3.11 from Homebrew
- [ ] Follow uv path and confirm `uv pip install` step works
- [ ] Confirm `slack-mcp-setup` runs correctly without venv activation
- [ ] Confirm MCP server works in Claude Code after deactivating the venv

🤖 Generated with [Claude Code](https://claude.com/claude-code)