### PR TITLE
fix(ci): add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to the CI workflow, restricting `GITHUB_TOKEN` to the minimum scope needed (checkout + test)
- Resolves CodeQL alert [#1](https://github.com/smartwatermelon/slack-mcp/security/code-scanning/1) (`actions/missing-workflow-permissions`, medium severity)

## Test plan

- [ ] CI passes with the restricted permissions (checkout and pytest still work with read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)